### PR TITLE
Refactor/perfomance low hanging fruits

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@sentry/node": "^6.0.3",
     "@sentry/tracing": "^6.0.3",
+    "cli-progress": "^3.9.0",
     "crypto-js": "^4.0.0",
     "debug": "^3.0.1",
     "dotenv": "^8.2.0",
@@ -24,6 +25,7 @@
     "signalr-client": "0.0.17"
   },
   "devDependencies": {
+    "@types/cli-progress": "^3.9.1",
     "@types/crypto-js": "^4.0.0",
     "@types/fancy-log": "^1.3.1",
     "@types/node": "^14.14.16",

--- a/src/modules/bot/index.ts
+++ b/src/modules/bot/index.ts
@@ -5,7 +5,6 @@ import now from 'performance-now';
 import { BittrexApi } from '../api';
 import {
   Balance,
-  Candle,
   Market,
   MarketDecision,
   MarketSummary,

--- a/src/modules/bot/index.ts
+++ b/src/modules/bot/index.ts
@@ -142,17 +142,16 @@ export default class Bot {
 
         if (!this.config.debug) {
           if (quantity > market.minTradeSize) {
+            log.info(
+              `${balance.currencySymbol} placed REVENUE SELL order for ${revenue} ${this.config.mainMarket}`
+            );
             const response = await this.api.sellLimit(
               market.symbol,
               quantity,
               ticker.bidRate
             );
-
             log.info(response);
           }
-          log.info(
-            `${balance.currencySymbol} placed REVENUE SELL order for ${revenue} ${this.config.mainMarket}`
-          );
         }
         await sleep(2500);
       }

--- a/src/modules/bot/index.ts
+++ b/src/modules/bot/index.ts
@@ -140,20 +140,19 @@ export default class Bot {
         );
         const quantity = revenue / ticker.bidRate;
 
-        if (!this.config.debug) {
-          if (quantity > market.minTradeSize) {
-            log.info(
-              `${balance.currencySymbol} placed REVENUE SELL order for ${revenue} ${this.config.mainMarket}`
-            );
-            const response = await this.api.sellLimit(
-              market.symbol,
-              quantity,
-              ticker.bidRate
-            );
-            log.info(response);
-          }
+        if (!this.config.debug && quantity > market.minTradeSize) {
+          log.info(
+            `${balance.currencySymbol} placed REVENUE SELL order ${quantity} for a total of ${revenue} ${this.config.mainMarket}`
+          );
+          const response = await this.api.sellLimit(
+            market.symbol,
+            quantity,
+            ticker.bidRate
+          );
+          log.info(response);
+          await sleep(1500);
         }
-        await sleep(2500);
+        await sleep(1500);
       }
       await sleep(1500);
     }

--- a/src/modules/bot/index.ts
+++ b/src/modules/bot/index.ts
@@ -125,7 +125,7 @@ export default class Bot {
         ({ currencySymbol }) => !this.config.HODL.includes(currencySymbol)
       );
 
-    await sleep(10000);
+    await sleep(1500);
 
     for (const balance of balances) {
       const ticker: MarketTicker = await this.api.getMarketTicker(

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,6 +120,13 @@
   dependencies:
     ajv "*"
 
+"@types/cli-progress@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.9.1.tgz#285e7fbdad6e7baf072d163ae1c3b23b7b219130"
+  integrity sha512-X/tKJv/GoYlCBS9wwJTLrVSxzIOI/Cj1cCatYOAAoQne3aT1QbHBptBS5+zLe2ToSljAijHU1N/ouBNFvZ2H/g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cross-spawn@^6.0.0":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
@@ -481,6 +488,14 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-progress@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.0.tgz#25db83447deb812e62d05bac1af9aec5387ef3d4"
+  integrity sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==
+  dependencies:
+    colors "^1.1.2"
+    string-width "^4.2.0"
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -519,6 +534,11 @@ color-name@~1.1.4:
 color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
Findings:
* Removed duplicate fetching of candles -> 1.5 seconds per market -> ~150 markets = saved ~225 seconds
* Unneeded long waiting in revenue collect after fetching balance saved 8.5 seconds

Also added progressbar. This won't improve perfomance but will make observing
![image](https://user-images.githubusercontent.com/2778161/111037469-64d06480-8424-11eb-85ab-815889df50b1.png)
